### PR TITLE
chore: move assess password strength logic into the useGeneratePassword hooks to get rid of the unnecessary useEffect

### DIFF
--- a/src/components/PasswordGenerator.tsx
+++ b/src/components/PasswordGenerator.tsx
@@ -5,7 +5,7 @@ import SettingsPanel from "./settingsPanel/SettingsPanel"
 import useGeneratePassword from "../hooks/useGeneratePassword"
 
 const PasswordGenerator = () => {
-  const { password, generatePassword } = useGeneratePassword()
+  const { password, generatePassword, passwordStrength } = useGeneratePassword()
 
   return (
     <Container maxWidth={false} disableGutters sx={{ display: "flex" }}>
@@ -18,7 +18,7 @@ const PasswordGenerator = () => {
         Password Generator
       </Typography>
       <Password generatedPassword={password} />
-      <SettingsPanel password={password} generatePassword={generatePassword} />
+      <SettingsPanel generatePassword={generatePassword} passwordStrength={passwordStrength} />
     </Container>
   )
 }

--- a/src/components/PasswordGenerator.tsx
+++ b/src/components/PasswordGenerator.tsx
@@ -18,7 +18,10 @@ const PasswordGenerator = () => {
         Password Generator
       </Typography>
       <Password generatedPassword={password} />
-      <SettingsPanel generatePassword={generatePassword} passwordStrength={passwordStrength} />
+      <SettingsPanel
+        generatePassword={generatePassword}
+        passwordStrength={passwordStrength}
+      />
     </Container>
   )
 }

--- a/src/components/passwordStrengthIndicator/PasswordStrengthBars.tsx
+++ b/src/components/passwordStrengthIndicator/PasswordStrengthBars.tsx
@@ -1,47 +1,19 @@
 import { Box, Typography } from "@mui/material"
 import "./PasswordStrengthBars.modules.css"
 import clsx from "clsx"
-import { FunctionComponent, useCallback, useEffect, useState } from "react"
+import { FunctionComponent } from "react"
 
 type PasswordStrengthBarsProps = {
-  password: string | undefined
+  passwordStrength: number
 }
 
 const PasswordStrengthBars: FunctionComponent<PasswordStrengthBarsProps> = ({
-  password,
+  passwordStrength,
 }) => {
-  const [passwordStrength, setPasswordStrength] = useState<number>(0)
-
   const tooWeak = passwordStrength <= 1
   const weak = passwordStrength === 2
   const medium = passwordStrength === 3
   const strong = passwordStrength === 4
-
-  const assessPasswordStrength = useCallback(() => {
-    if (!password) {
-      return
-    }
-
-    const containsNumbers = /\d/.test(password)
-    const containsUpperCase = /[A-Z]/.test(password)
-    const containsLowerCase = /[a-z]/.test(password)
-    const containsSymbols = /[ `!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?~]/.test(
-      password,
-    )
-
-    const passwordChecks = [
-      containsNumbers,
-      containsUpperCase,
-      containsLowerCase,
-      containsSymbols,
-    ]
-
-    setPasswordStrength(passwordChecks.filter(Boolean).length)
-  }, [password])
-
-  useEffect(() => {
-    assessPasswordStrength()
-  }, [password, assessPasswordStrength])
 
   const passwordStrengthText = () => {
     if (tooWeak) return "TOO WEAK!"

--- a/src/components/passwordStrengthIndicator/PasswordStrengthIndicator.tsx
+++ b/src/components/passwordStrengthIndicator/PasswordStrengthIndicator.tsx
@@ -4,18 +4,18 @@ import PasswordStrengthBars from "./PasswordStrengthBars"
 import { FunctionComponent } from "react"
 
 type PasswordStrengthIndicatorProps = {
-  password: string | undefined
+  passwordStrength: number
 }
 
 const PasswordStrengthIndicator: FunctionComponent<
   PasswordStrengthIndicatorProps
-> = ({ password }) => {
+> = ({ passwordStrength }) => {
   return (
     <Box className="box">
       <Typography variant="h3" className="text">
         STRENGTH
       </Typography>
-      <PasswordStrengthBars password={password} />
+      <PasswordStrengthBars passwordStrength={passwordStrength} />
     </Box>
   )
 }

--- a/src/components/settingsPanel/SettingsPanel.tsx
+++ b/src/components/settingsPanel/SettingsPanel.tsx
@@ -11,13 +11,13 @@ import useSettingsContext from "../../hooks/useSettingsContext"
 import clsx from "clsx"
 
 type SettingsPanelProps = {
-  password: string | undefined
   generatePassword: () => void
+  passwordStrength: number
 }
 
 const SettingsPanel: FunctionComponent<SettingsPanelProps> = ({
-  password,
   generatePassword,
+  passwordStrength,
 }) => {
   const { enabledSettings } = useSettingsContext()
 
@@ -27,7 +27,7 @@ const SettingsPanel: FunctionComponent<SettingsPanelProps> = ({
     <CardWrapper className="cardContainer" dataTest="SettingsPanel:container">
       <CharacterLengthSlider />
       <SettingsCheckboxes />
-      <PasswordStrengthIndicator password={password} />
+      <PasswordStrengthIndicator passwordStrength={passwordStrength} />
       <Button
         className={clsx("generateButton", { disabled: noEnabledSettings })} //
         onClick={generatePassword}

--- a/src/hooks/useGeneratePassword.ts
+++ b/src/hooks/useGeneratePassword.ts
@@ -14,6 +14,7 @@ const useGeneratePassword = () => {
   const [generatedPassword, setGeneratedPassword] = useState<
     string | undefined
   >(undefined)
+  const [passwordStrength, setPasswordStrength] = useState<number>(0)
   const crypto = window.crypto
 
   const numbers = "1234567890"
@@ -80,6 +81,7 @@ const useGeneratePassword = () => {
       .join("")
 
     setGeneratedPassword(shuffledPassword)
+    assessPasswordStrength(shuffledPassword)
   }, [
     enabledSettings,
     retrieveRandomCharacters,
@@ -90,7 +92,34 @@ const useGeneratePassword = () => {
     passwordCharacterLength,
   ])
 
-  return { password: generatedPassword, generatePassword }
+  const assessPasswordStrength = useCallback((password: string
+  ) => {
+    if (!password) {
+      return
+    }
+
+    const containsNumbers = /\d/.test(password)
+    const containsUpperCase = /[A-Z]/.test(password)
+    const containsLowerCase = /[a-z]/.test(password)
+    const containsSymbols = /[ `!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?~]/.test(
+      password,
+    )
+
+    const passwordChecks = [
+      containsNumbers,
+      containsUpperCase,
+      containsLowerCase,
+      containsSymbols,
+    ]
+
+    setPasswordStrength(passwordChecks.filter(Boolean).length)
+  }, [])
+
+  return {
+    password: generatedPassword,
+    generatePassword,
+    passwordStrength,
+  }
 }
 
 export default useGeneratePassword

--- a/src/hooks/useGeneratePassword.ts
+++ b/src/hooks/useGeneratePassword.ts
@@ -37,6 +37,28 @@ const useGeneratePassword = () => {
     [crypto, enabledSettings, passwordCharacterLength],
   )
 
+  const assessPasswordStrength = useCallback((password: string) => {
+    if (!password) {
+      return
+    }
+
+    const containsNumbers = /\d/.test(password)
+    const containsUpperCase = /[A-Z]/.test(password)
+    const containsLowerCase = /[a-z]/.test(password)
+    const containsSymbols = /[ `!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?~]/.test(
+      password,
+    )
+
+    const passwordChecks = [
+      containsNumbers,
+      containsUpperCase,
+      containsLowerCase,
+      containsSymbols,
+    ]
+
+    setPasswordStrength(passwordChecks.filter(Boolean).length)
+  }, [])
+
   const generatePassword = useCallback(() => {
     const characterSet = [
       ...(includeUpperCase ? upperCaseLetters : []),
@@ -90,30 +112,8 @@ const useGeneratePassword = () => {
     includeSymbols,
     includeUpperCase,
     passwordCharacterLength,
+    assessPasswordStrength,
   ])
-
-  const assessPasswordStrength = useCallback((password: string
-  ) => {
-    if (!password) {
-      return
-    }
-
-    const containsNumbers = /\d/.test(password)
-    const containsUpperCase = /[A-Z]/.test(password)
-    const containsLowerCase = /[a-z]/.test(password)
-    const containsSymbols = /[ `!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?~]/.test(
-      password,
-    )
-
-    const passwordChecks = [
-      containsNumbers,
-      containsUpperCase,
-      containsLowerCase,
-      containsSymbols,
-    ]
-
-    setPasswordStrength(passwordChecks.filter(Boolean).length)
-  }, [])
 
   return {
     password: generatedPassword,


### PR DESCRIPTION
I didn't really like the way I used an useEffect to execute the assessPasswordStrength function in the src/components/passwordStrengthIndicator/PasswordStrengthBars.tsx component since it's clanky and it doesn't seem intuitive because the useEffect here is definitely not needed. I decided to move the logic for assessing the password strength into the useGeneratePassword hooks to eliminate the need of any useEffect. I now execute the assessPasswordStrength upon generating the password.

After code reviewing again I believe that we should avoid using useEffect as much as possible unless it's really needed like for handling some side effects because heavily relying on useEffect would promote bad practices like how my previous changes look. Why would I make a function and then call that function within a useEffect in the same component? If I look at the bigger picture I only need to execute the assessPasswordFunction when I generate the password not when the PasswordStrengthBars.tsx component rerenders.